### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 家居声控系统
 ==================
-#目标
+# 目标
 * 开发一个全智能的语音识别机器人,期望安装在树莓派上，然后控制家里的家电，并且可以控制linux内核的笔记本等设备识别指令集
 
-#开发语言
+# 开发语言
 * python
 
-#python依赖包(推荐使用easy_install安装依赖)
+# python依赖包(推荐使用easy_install安装依赖)
 * requests
 * pyzmq
 * pyaudio(如若提示portaudio错误，请安装就可以了)
@@ -22,19 +22,19 @@
 * gntp
 * wolframalpha
 
-#linux依赖包
+# linux依赖包
 * growl for linux
 * pico2wave
 * sudo apt-get install espeak
 
-#如何使用
+# 如何使用
 * 启动gol(growl on linux) 我编译安装之后路径如下/usr/local/bin/gol
 * python startup.py
 
-#系统架构图
+# 系统架构图
 ![家居声控系统图](http://www.echocool.net/wp-content/uploads/2013/09/sys.png)
 
-#Todolist
+# Todolist
 * 静音判断
 * 搜索指令集需要分类(可以借助dbpedia)，例如人物，音乐，学习，编程手册等等
 * 语音识别本地化，Julius speech recogition是一个开源的项目
@@ -42,7 +42,7 @@
 * 加入新闻机器人的功能，以后看新闻就可以不用那么多网站找了（想法是可以找英文和科技）英文我发现有个拓词和百词斩非常不错
 * 命令分类：电视,空调,唱歌,编程,新闻,图片,天气预报(目前就这几类,后面可以添加),先找命令类型，然后执行详细命令 例如电视频道50(分词结果电视频道,50) 电视 先找到电视类别，然后执行频道50
 
-#has done
+# has done
 * 录音功能，最长录音时间5S，如果中间停顿次数多余15次会提前终止此次录音
 * stt功能，将上一步的录音通过google api 翻译音频内容
 * command功能 根据上一步google api 返回的内容，进行简单指令操作
@@ -56,7 +56,7 @@
 * 利用树莓派嵌入式的优势，然后开发控制tv，空调等指令 --PS:这个已经实现了，请关注红外控制系统[piInfrated](https://github.com/apanly/piInfrated)
 
 
-#doing
+# doing
 * Yahoo由14个基本大类组成，包括
     Art＆Humanities(艺术与人文)、Business＆Economy(商业与经济)、
     Computers＆Internet(电脑与网际网路/网络)、Education(教育)、
@@ -70,7 +70,7 @@
 * 语音识别可以修改成Kaldi(google被墙了)
 
 
-#参考文档如下
+# 参考文档如下
 * [Linux音频编程指南](http://www.ibm.com/developerworks/cn/linux/l-audio/index.html)
 * [python pyaudio doc](http://people.csail.mit.edu/hubert/pyaudio/#docs)
 * [Gordons Projects](https://projects.drogon.net/raspberry-pi/wiringpi/)
@@ -92,10 +92,10 @@
 * [Raspberry Pi创意大荟萃](http://guiquanz.github.io/2013/01/04/projects-of-raspberry-pi/)
 * [几个常见的语音交互平台的简介和比较](http://blog.csdn.net/lchunli/article/details/18504799)
 
-#How to Contact
-##QQ:36405410
-##Email:apanly@163.com
+# How to Contact
+## QQ:36405410
+## Email:apanly@163.com
 
 
-#Copying
-###Free use of this software is granted under the terms of the GNU Lesser General Public License (LGPL)
+# Copying
+### Free use of this software is granted under the terms of the GNU Lesser General Public License (LGPL)

--- a/install.md
+++ b/install.md
@@ -12,7 +12,7 @@ Running PyAudio-0.2.7/setup.py -q bdist_egg --dist-dir /var/folders/vg/98k5hfl52
 warning: no files found matching '*.c' under directory 'test'
 clang: warning: argument unused during compilation: '-mno-fused-madd'
 src/_portaudiomodule.c:29:10: fatal error: 'portaudio.h' file not found
-#include "portaudio.h"
+# include "portaudio.h"
          ^
 1 error generated.
 
@@ -22,7 +22,7 @@ src/_portaudiomodule.c:29:10: fatal error: 'portaudio.h' file not found
 * 安装PIL，遇到以下错误(on max os)
 clang: warning: argument unused during compilation: '-mno-fused-madd'
 _imagingft.c:73:10: fatal error: 'freetype/fterrors.h' file not found
-#include <freetype/fterrors.h>
+# include <freetype/fterrors.h>
          ^
 1 error generated.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
